### PR TITLE
Use projects absolute path in pack task

### DIFF
--- a/2.1.08-Exercise-CreatingATextureAtlas/build.gradle
+++ b/2.1.08-Exercise-CreatingATextureAtlas/build.gradle
@@ -100,28 +100,20 @@ project(":core") {
     }
 
     // TODO: Define packTextures task
-    task packTextures << {
-       // NOTE: When using android studio gradle executes from a different working directory
-       final def absolutePath = project.getRootDir().absolutePath
+    task packTextures {
+        final def prefix = project.getRootDir().absolutePath + "/";
 
-       final def packPath  = absolutePath + "/android/assets/images/gigagal.pack.png"
-       final def atlasPath = absolutePath + "/android/assets/images/gigagal.pack.atlas"
+        def pack = new File(prefix + "android/assets/images/gigagal.pack.png")
+        pack.delete()
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
+        atlas.delete()
+        TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
+    }
 
-       final def spriteSourceDir     = absolutePath + "/core/rawAssets/sprites"
-       final def packFileName        = "gigagal.pack"
-       final def textureAtlasDestDir = absolutePath + "/android/assets/images"
+    // TODO: Add task dependency between compileJava and packTextures
+    project.tasks.compileJava.dependsOn packTextures
 
-       def pack = new File(packPath)
-       pack.delete()
 
-       def atlas = new File(atlasPath)
-       atlas.delete()
-
-       TexturePacker.process(spriteSourceDir, textureAtlasDestDir, packFileName)
-   }
-
-   // TODO: Add task dependency between compileJava and packTextures
-   project.tasks.compileJava.dependsOn packTextures
 }
 
 tasks.eclipse.doLast {

--- a/2.1.08-Exercise-CreatingATextureAtlas/build.gradle
+++ b/2.1.08-Exercise-CreatingATextureAtlas/build.gradle
@@ -101,17 +101,27 @@ project(":core") {
 
     // TODO: Define packTextures task
     task packTextures << {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        pack.delete()
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
-        atlas.delete()
-        TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
-    }
+       // NOTE: When using android studio gradle executes from a different working directory
+       final def absolutePath = project.getRootDir().absolutePath
 
-    // TODO: Add task dependency between compileJava and packTextures
-    project.tasks.compileJava.dependsOn packTextures
+       final def packPath  = absolutePath + "/android/assets/images/gigagal.pack.png"
+       final def atlasPath = absolutePath + "/android/assets/images/gigagal.pack.atlas"
 
+       final def spriteSourceDir     = absolutePath + "/core/rawAssets/sprites"
+       final def packFileName        = "gigagal.pack"
+       final def textureAtlasDestDir = absolutePath + "/android/assets/images"
 
+       def pack = new File(packPath)
+       pack.delete()
+
+       def atlas = new File(atlasPath)
+       atlas.delete()
+
+       TexturePacker.process(spriteSourceDir, textureAtlasDestDir, packFileName)
+   }
+
+   // TODO: Add task dependency between compileJava and packTextures
+   project.tasks.compileJava.dependsOn packTextures
 }
 
 tasks.eclipse.doLast {

--- a/2.1.08-Solution-CreatingATextureAtlas/build.gradle
+++ b/2.1.08-Solution-CreatingATextureAtlas/build.gradle
@@ -100,28 +100,20 @@ project(":core") {
     }
 
     // TODO: Define packTextures task
-    task packTextures << {
-       // NOTE: When using android studio gradle executes from a different working directory
-       final def absolutePath = project.getRootDir().absolutePath
+    task packTextures {
+        final def prefix = project.getRootDir().absolutePath + "/"
 
-       final def packPath  = absolutePath + "/android/assets/images/gigagal.pack.png"
-       final def atlasPath = absolutePath + "/android/assets/images/gigagal.pack.atlas"
+        def pack = new File(prefix + "android/assets/images/gigagal.pack.png")
+        pack.delete()
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
+        atlas.delete()
+        TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
+    }
 
-       final def spriteSourceDir     = absolutePath + "/core/rawAssets/sprites"
-       final def packFileName        = "gigagal.pack"
-       final def textureAtlasDestDir = absolutePath + "/android/assets/images"
+    // TODO: Add task dependency between compileJava and packTextures
+    project.tasks.compileJava.dependsOn packTextures
 
-       def pack = new File(packPath)
-       pack.delete()
 
-       def atlas = new File(atlasPath)
-       atlas.delete()
-
-       TexturePacker.process(spriteSourceDir, textureAtlasDestDir, packFileName)
-   }
-
-   // TODO: Add task dependency between compileJava and packTextures
-   project.tasks.compileJava.dependsOn packTextures
 }
 
 tasks.eclipse.doLast {

--- a/2.1.08-Solution-CreatingATextureAtlas/build.gradle
+++ b/2.1.08-Solution-CreatingATextureAtlas/build.gradle
@@ -101,17 +101,27 @@ project(":core") {
 
     // TODO: Define packTextures task
     task packTextures << {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        pack.delete()
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
-        atlas.delete()
-        TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
-    }
+       // NOTE: When using android studio gradle executes from a different working directory
+       final def absolutePath = project.getRootDir().absolutePath
 
-    // TODO: Add task dependency between compileJava and packTextures
-    project.tasks.compileJava.dependsOn packTextures
+       final def packPath  = absolutePath + "/android/assets/images/gigagal.pack.png"
+       final def atlasPath = absolutePath + "/android/assets/images/gigagal.pack.atlas"
 
+       final def spriteSourceDir     = absolutePath + "/core/rawAssets/sprites"
+       final def packFileName        = "gigagal.pack"
+       final def textureAtlasDestDir = absolutePath + "/android/assets/images"
 
+       def pack = new File(packPath)
+       pack.delete()
+
+       def atlas = new File(atlasPath)
+       atlas.delete()
+
+       TexturePacker.process(spriteSourceDir, textureAtlasDestDir, packFileName)
+   }
+
+   // TODO: Add task dependency between compileJava and packTextures
+   project.tasks.compileJava.dependsOn packTextures
 }
 
 tasks.eclipse.doLast {

--- a/2.2.03-Exercise-AssetLoading/build.gradle
+++ b/2.2.03-Exercise-AssetLoading/build.gradle
@@ -99,18 +99,20 @@ project(":core") {
 
 
     // TODO: Uncomment the following definition of the packTextures task
-//    task packTextures {
-//        def pack = new File("android/assets/images/gigagal.pack.png")
-//        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    //task packTextures  {
+//        final def prefix = project.getRootDir().absolutePath + "/";
+//
+//        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+//        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 //
 //        doLast {
 //            pack.delete()
 //            atlas.delete()
-//            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+//            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
 //        }
 //    }
 
-    // TODO: Uncomment the following line declaring a dependency between compileJava and packTextures
+      // TODO: Uncomment the following line declaring a dependency between compileJava and packTextures
 //    project.tasks.compileJava.dependsOn packTextures
 }
 

--- a/2.2.03-Solution-AssetLoading/build.gradle
+++ b/2.2.03-Solution-AssetLoading/build.gradle
@@ -99,14 +99,16 @@ project(":core") {
 
 
     // TODO: Uncomment the following definition of the packTextures task
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.04-Exercise-DrawGigaGal/build.gradle
+++ b/2.2.04-Exercise-DrawGigaGal/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites",prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.04-Solution-DrawGigaGal/build.gradle
+++ b/2.2.04-Solution-DrawGigaGal/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.05-Exercise-LeftAndRightMovement/build.gradle
+++ b/2.2.05-Exercise-LeftAndRightMovement/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.05-Solution-LeftAndRightMovement/build.gradle
+++ b/2.2.05-Solution-LeftAndRightMovement/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix +  "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.06-Exercise-FacingDirection/build.gradle
+++ b/2.2.06-Exercise-FacingDirection/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.06-Solution-FacingDirection/build.gradle
+++ b/2.2.06-Solution-FacingDirection/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.07-Exercise-SetUpJumping/build.gradle
+++ b/2.2.07-Exercise-SetUpJumping/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+    task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.07-Solution-SetUpJumping/build.gradle
+++ b/2.2.07-Solution-SetUpJumping/build.gradle
@@ -94,9 +94,11 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()

--- a/2.2.08-Exercise-JumpingSprites/build.gradle
+++ b/2.2.08-Exercise-JumpingSprites/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.08-Solution-JumpingSprites/build.gradle
+++ b/2.2.08-Solution-JumpingSprites/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.09-Exercise-WalkState/build.gradle
+++ b/2.2.09-Exercise-WalkState/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.09-Solution-WalkState/build.gradle
+++ b/2.2.09-Solution-WalkState/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.10-Exercise-WalkLoop/build.gradle
+++ b/2.2.10-Exercise-WalkLoop/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.2.10-Solution-WalkLoop/build.gradle
+++ b/2.2.10-Solution-WalkLoop/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.3.01-Exercise-BasicPlatforms/build.gradle
+++ b/2.3.01-Exercise-BasicPlatforms/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.3.01-Solution-BasicPlatforms/build.gradle
+++ b/2.3.01-Solution-BasicPlatforms/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.3.02-Exercise-9PatchPlatforms/build.gradle
+++ b/2.3.02-Exercise-9PatchPlatforms/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.3.02-Solution-9PatchPlatforms/build.gradle
+++ b/2.3.02-Solution-9PatchPlatforms/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.3.03-Exercise-ComingInForALanding/build.gradle
+++ b/2.3.03-Exercise-ComingInForALanding/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.3.03-Solution-ComingInForALanding/build.gradle
+++ b/2.3.03-Solution-ComingInForALanding/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.3.04-Exercise-AddDebugPlatforms/build.gradle
+++ b/2.3.04-Exercise-AddDebugPlatforms/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.3.04-Solution-AddDebugPlatforms/build.gradle
+++ b/2.3.04-Solution-AddDebugPlatforms/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.01-Exercise-ChaseCamera/build.gradle
+++ b/2.4.01-Exercise-ChaseCamera/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.01-Solution-ChaseCamera/build.gradle
+++ b/2.4.01-Solution-ChaseCamera/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.02-Exercise-RemoveTheFloor/build.gradle
+++ b/2.4.02-Exercise-RemoveTheFloor/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.02-Solution-RemoveTheFloor/build.gradle
+++ b/2.4.02-Solution-RemoveTheFloor/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.03-Exercise-AddAKillPlane/build.gradle
+++ b/2.4.03-Exercise-AddAKillPlane/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.03-Solution-AddAKillPlane/build.gradle
+++ b/2.4.03-Solution-AddAKillPlane/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.04-Exercise-MorePlatforms/build.gradle
+++ b/2.4.04-Exercise-MorePlatforms/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.04-Solution-MorePlatforms/build.gradle
+++ b/2.4.04-Solution-MorePlatforms/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.05-Exercise-DebugCameraControls/build.gradle
+++ b/2.4.05-Exercise-DebugCameraControls/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/2.4.05-Solution-DebugCameraControls/build.gradle
+++ b/2.4.05-Solution-DebugCameraControls/build.gradle
@@ -94,14 +94,16 @@ project(":core") {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 

--- a/GigaGalPrototype/build.gradle
+++ b/GigaGalPrototype/build.gradle
@@ -92,19 +92,18 @@ project(":core") {
 
     dependencies {
         compile "com.badlogicgames.gdx:gdx:$gdxVersion"
-        compile ('com.googlecode.json-simple:json-simple:1.1.1') {
-            exclude module: 'junit'
-        }
     }
 
-    task packTextures {
-        def pack = new File("android/assets/images/gigagal.pack.png")
-        def atlas = new File("android/assets/images/gigagal.pack.atlas")
+	task packTextures << {
+        final def prefix = project.getRootDir().absolutePath + "/"
+
+        def pack  = new File(prefix + "android/assets/images/gigagal.pack.png")
+        def atlas = new File(prefix + "android/assets/images/gigagal.pack.atlas")
 
         doLast {
             pack.delete()
             atlas.delete()
-            TexturePacker.process("core/rawAssets/sprites", "android/assets/images", "gigagal.pack")
+            TexturePacker.process(prefix + "core/rawAssets/sprites", prefix + "android/assets/images", "gigagal.pack")
         }
     }
 


### PR DESCRIPTION
This is either an android studio issue or a problem with windows.

Maybe @JeremySilverTongue can expand on some of this... i'm not to familiar with android studio & gradle.

When running android studio, if you setup a desktop configuration and hit the "Run" button an exception occurs when trying running the pack task in the **:desktop** build. This appears to be caused due to the fact that when gradle runs in android studio, it runs via a wrapper in a temp directory so the relative paths are not correct.

Whats interesting is that although the exception is thrown, the pack files are still generated. I think the gradle files for **:core** are being invoked in another way when syncing or compiling **:desktop** which actually generates the files during the execution of the **:core** build.

Another way around this issue in android studio is to actually add a build step in the build configurations to explicitly run the :packTextures task. It appears when done this way it still maintains your directory structure. Note that if you do this, you must also remove the compile dependency from the build.gradle file so it isn't invoked during the compile step.

I assume this issue probably exists with some other files in this lesson but i'm not quite on those yet.

I believe this also fixes issue #6 